### PR TITLE
Taskを未完了状態に戻す処理のリファクタ

### DIFF
--- a/todo/application/task/__init__.py
+++ b/todo/application/task/__init__.py
@@ -39,7 +39,7 @@ class TaskUpdateService:
         if finished:
             modified_task = task.to_finished_now()
         else:
-            modified_task = task.with_finished_at(finished_at=None)
+            modified_task = task.to_canceled_finish()
 
         self.task_repository.save(task=modified_task)
 

--- a/todo/domain/__init__.py
+++ b/todo/domain/__init__.py
@@ -83,6 +83,9 @@ class Task:
     def with_finished_at(self, finished_at: Optional[datetime.datetime]) -> "Task":
         return self._clone(finished_at=finished_at)
 
+    def to_canceled_finish(self) -> "Task":
+        return self._clone(finished_at=None)
+
     def to_finished_now(self) -> "Task":
         return self.with_finished_at(
             finished_at=datetime.datetime.utcnow().astimezone(tz=datetime.timezone.utc)


### PR DESCRIPTION
## チュートリアルのセクション４の課題の2問目
> Task のメソッド with_finished_at() に None を渡すと未完了状態に戻る実装は、「タスクを未完了に戻す」という行為を行いたい利用者(ApplicationService)の視点から見ると、過剰に内部実装を知る必要があり好ましくありません。リファクタリングしてみましょう。

* 未完了状態に戻すメソッド `to_canceled_finish` をTaskモデルに追加
* `TaskUpdateService` で `to_canceled_finish` を利用するように変更