### PR TITLE
登録済みのタスクの名前変更を可能にする

### DIFF
--- a/templates/todo/tasks.html
+++ b/templates/todo/tasks.html
@@ -12,10 +12,14 @@
         <li>
             {% if task.is_finished %}✔{% endif %}
             {{ task.name.value }} ({{ task.created_at.isoformat() }})
+            <form action="/tasks/{{ task.key.task_id }}/update/name" method="post">
+                <input type="text" name="new_task_name">
+                <input type="submit" value="rename">
+            </form>
             <form action="/tasks/{{ task.key.task_id }}/delete" method="post">
                 <input type="submit" value="delete">
             </form>
-            <form action="/tasks/{{ task.key.task_id }}/update" method="post">
+            <form action="/tasks/{{ task.key.task_id }}/update/status" method="post">
                 {% if task.is_finished %}
                     <input type="hidden" name="finished" value="false">
                     <input type="submit" value="undone">

--- a/tests/todo/application/task/test_service.py
+++ b/tests/todo/application/task/test_service.py
@@ -2,7 +2,7 @@ import main
 
 from gumo.datastore.infrastructure.test_utils import DatastoreRepositoryMixinForTest
 from todo.application.task.repository import TaskRepository
-from todo.application.task import TaskCreateService, TaskStatusUpdateService
+from todo.application.task import TaskCreateService, TaskStatusUpdateService, TaskNameUpdateService
 from todo.domain import TaskKey
 
 
@@ -20,15 +20,22 @@ class TestTaskService(DatastoreRepositoryMixinForTest):
 
         assert self.count_entities() == 1
 
-    def test_update_service(self):
-        self.cleanup_entities()
-        assert self.count_entities() == 0
-
+    def test_status_update_service(self):
         task_name = "TaskName"
         create_service = main.injector.get(TaskCreateService)
         task = create_service.execute(task_name=task_name)
 
-        update_service = main.injector.get(TaskStatusUpdateService)
-        updated_task = update_service.execute(key=task.key, finished=True)
+        status_update_service = main.injector.get(TaskStatusUpdateService)
+        updated_task = status_update_service.execute(key=task.key, finished=True)
 
         assert updated_task.is_finished
+
+    def test_task_name_update_service(self):
+        task_name = "TaskName"
+        create_service = main.injector.get(TaskCreateService)
+        task = create_service.execute(task_name=task_name)
+
+        task_name_update_service = main.injector.get(TaskNameUpdateService)
+        updated_task = task_name_update_service.execute(key=task.key, task_name="NewTaskName")
+
+        assert updated_task.name.value == "NewTaskName"

--- a/tests/todo/application/task/test_service.py
+++ b/tests/todo/application/task/test_service.py
@@ -2,7 +2,7 @@ import main
 
 from gumo.datastore.infrastructure.test_utils import DatastoreRepositoryMixinForTest
 from todo.application.task.repository import TaskRepository
-from todo.application.task import TaskCreateService, TaskUpdateService
+from todo.application.task import TaskCreateService, TaskStatusUpdateService
 from todo.domain import TaskKey
 
 
@@ -28,7 +28,7 @@ class TestTaskService(DatastoreRepositoryMixinForTest):
         create_service = main.injector.get(TaskCreateService)
         task = create_service.execute(task_name=task_name)
 
-        update_service = main.injector.get(TaskUpdateService)
+        update_service = main.injector.get(TaskStatusUpdateService)
         updated_task = update_service.execute(key=task.key, finished=True)
 
         assert updated_task.is_finished

--- a/todo/application/task/__init__.py
+++ b/todo/application/task/__init__.py
@@ -28,7 +28,7 @@ class TaskCreateService:
         return task
 
 
-class TaskUpdateService:
+class TaskStatusUpdateService:
     @inject
     def __init__(self, task_repository: TaskRepository):
         self.task_repository = task_repository
@@ -40,6 +40,20 @@ class TaskUpdateService:
             modified_task = task.to_finished_now()
         else:
             modified_task = task.with_finished_at(finished_at=None)
+
+        self.task_repository.save(task=modified_task)
+
+        return modified_task
+
+
+class TaskNameUpdateService:
+    @inject
+    def __init__(self, task_repository: TaskRepository):
+        self.task_repository = task_repository
+
+    def execute(self, key: TaskKey, task_name: str) -> "Task":
+        task = self.task_repository.fetch(key=key)
+        modified_task = task.to_changed_task_name(task_name=TaskName(task_name))
 
         self.task_repository.save(task=modified_task)
 

--- a/todo/domain/__init__.py
+++ b/todo/domain/__init__.py
@@ -87,3 +87,6 @@ class Task:
         return self.with_finished_at(
             finished_at=datetime.datetime.utcnow().astimezone(tz=datetime.timezone.utc)
         )
+
+    def to_changed_task_name(self, task_name: TaskName) -> "Task":
+        return self._clone(name=task_name)

--- a/todo/presentation/__init__.py
+++ b/todo/presentation/__init__.py
@@ -1,6 +1,6 @@
 import flask
 
-from todo.presentation.task import TasksView, TaskDeleteView, TaskUpdateView
+from todo.presentation.task import TasksView, TaskDeleteView, TaskStatusUpdateView, TaskNameUpdateView
 
 
 def register_views(blueprint: flask.Blueprint):
@@ -17,7 +17,13 @@ def register_views(blueprint: flask.Blueprint):
     )
 
     blueprint.add_url_rule(
-        rule="/tasks/<task_id>/update",
-        view_func=TaskUpdateView.as_view("tasks/update"),
+        rule="/tasks/<task_id>/update/status",
+        view_func=TaskStatusUpdateView.as_view("tasks/update/status"),
+        methods=["POST"]
+    )
+
+    blueprint.add_url_rule(
+        rule="/tasks/<task_id>/update/name",
+        view_func=TaskNameUpdateView.as_view("tasks/update/name"),
         methods=["POST"]
     )

--- a/todo/presentation/task/__init__.py
+++ b/todo/presentation/task/__init__.py
@@ -2,7 +2,7 @@ import flask.views
 
 from gumo.core.injector import injector
 from todo.application.task.repository import TaskRepository
-from todo.application.task import TaskCreateService, TaskUpdateService
+from todo.application.task import TaskCreateService, TaskStatusUpdateService, TaskNameUpdateService
 from todo.domain import TaskKey
 
 
@@ -30,11 +30,21 @@ class TaskDeleteView(flask.views.MethodView):
         return flask.redirect("/tasks")
 
 
-class TaskUpdateView(flask.views.MethodView):
+class TaskStatusUpdateView(flask.views.MethodView):
     def post(self, task_id):
         task_key = TaskKey.build_by_id(task_id=task_id)
         finished = flask.request.form.get("finished", "false") == "true"
-        service: TaskUpdateService = injector.get(TaskUpdateService)
+        service: TaskStatusUpdateService = injector.get(TaskStatusUpdateService)
         service.execute(key=task_key, finished=finished)
+
+        return flask.redirect("/tasks")
+
+
+class TaskNameUpdateView(flask.views.MethodView):
+    def post(self, task_id):
+        task_key = TaskKey.build_by_id(task_id=task_id)
+        task_name: str = flask.request.form.get("new_task_name", "")
+        service: TaskNameUpdateService = injector.get(TaskNameUpdateService)
+        service.execute(key=task_key, task_name=task_name)
 
         return flask.redirect("/tasks")


### PR DESCRIPTION
## チュートリアルのセクション4の課題3問目
> 登録済みのタスクの名前を変更できるように実装してみましょう。

*  `TaskNameUpdateService`を追加
*  タスク名の変更フォームを追加する
<img width="358" alt="スクリーンショット 2019-12-29 17 28 13" src="https://user-images.githubusercontent.com/11240481/71554297-bdeeeb00-2a60-11ea-85a9-8f096f5de0b1.png">
